### PR TITLE
Fix a pair covariance bug in radiometer

### DIFF
--- a/maps/anis_pta.py
+++ b/maps/anis_pta.py
@@ -615,7 +615,7 @@ class anis_pta():
         # the power in each pixel assuming no power in others, i.e. radiometer!
 
         # Get the full fisher matrix
-        fisher_mat = self.fisher_matrix_pixel()
+        fisher_mat = self.fisher_matrix_pixel(pair_cov)
         # Get only the diagonal elements and invert
         fisher_diag_inv = np.diag( 1/np.diag(fisher_mat) )
     

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     # Needed for dependencies
     install_requires=['numpy', 'scipy', 'sympy', 'astroML', 'PTMCMCSampler', 'healpy', 'lmfit'],
     # *strongly* suggested for sharing
-    version='0.4.2',
+    version='0.4.3',
     # The license can be anything you like
     license='MIT',
     description='Package to generate sky maps for PTA stochastic gravitational wave backgrounds.',


### PR DESCRIPTION
@TTMoursy Found an issue where the fisher matrix was not properly using pair covariance in the radiometer pixel basis. Small change and version number bump.